### PR TITLE
Move from Dockerfile to Containerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [Unreleased] 
+
+- Updated links to the tutorial
+- Updated Requirements to include HZDC7C0 for z/OS 2.5 and later
+- [#3] move to Containerfile (needs docker build to include -f Containerfile)
 
 ## [0.3.1] - 2022-02-08
 
-### Added
 - Added a changelog
 
-[unreleased]: https://github.com/ibm/repo-template/compare/v0.0.1...HEAD
-[0.3.1]: https://github.com/ibm/repo-template/releases/tag/v0.0.1
+[unreleased]: https://github.com/ibm/sftp-only-container/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/ibm/sftp-only-container/releases/tag/0.3.1

--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ LABEL org.opencontainers.image.source="https://github.com/IBM/sftp-only-containe
 LABEL org.opencontainers.image.vendor="IBM"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 #LABEL description="A ssh container with an simple method to import public keys"
-LABEL org.opencontainers.image.version="0.3.1"
+LABEL org.opencontainers.image.version="0.3.2"
 
 RUN microdnf --nodocs -y install openssh-server sudo && \
     microdnf clean all

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 <!-- Not always needed, but a scope helps the user understand in a short sentance like below, why this repo exists -->
 ## Scope
 
-container files and shell scripts for the IBM Developer tutorial sftp-only
+**Note:** Fix for [#3] will require the build on docker to add the parameter `-f Containerfile` and is only automaticaly working on podman.
+
+Container files and shell scripts for the IBM Developer tutorial sftp-only
 container for IBM zCX (or any other appliance-like container runtime).
 
 [Share volumes from the IBM z/OS Container Extension using SFTP on IBM Developer](https://developer.ibm.com/tutorials/sharing-volumes-from-the-ibm-zos-container-extension-using-sftp-or-scp/)


### PR DESCRIPTION
Fixes #3

Requires updates to tutorial (docker build -f Containerfile). We probably do not merge that to main.